### PR TITLE
Fixes building of Query Params with multiple recipients

### DIFF
--- a/BuildQueryParameters.pas
+++ b/BuildQueryParameters.pas
@@ -33,15 +33,18 @@ const
   ACTION = 'SendEmail';
 var
   I: Integer;
-  BodyType: string;
+  BodyType, Recipient: string;
 begin
   Result := TStringStream.Create(EmptyStr, TEncoding.UTF8);
   try
     Result.WriteString('Action=' + ACTION);
     Result.WriteString(Format('&Source=%s', [TEncodeQueryParams.Encode(From)]));
+
     for I := 0 to Recipients.Count -1 do
-      Result.WriteString(Format('&Destination.ToAddresses.member.%d=%s',
-        [I+1, TEncodeQueryParams.Encode(Recipients[I])]));
+    begin
+      Recipient := Format('&Destination.ToAddresses.member.%d=%s', [I+1, TEncodeQueryParams.Encode(Recipients[I])]);
+      Result.WriteString(Recipient);
+    end;
 
     Result.WriteString('&Message.Subject.Charset=UTF-8');
     Result.WriteString(Format('&Message.Subject.Data=%s', [TEncodeQueryParams.Encode(Subject)]));

--- a/EncodeQueryParams.pas
+++ b/EncodeQueryParams.pas
@@ -5,7 +5,7 @@ interface
 type
   TEncodeQueryParams = class
   public
-    class function Encode(const Str: string): string; overload;
+    class function Encode(const Str: string): string; static;
   end;
 
 implementation
@@ -19,6 +19,7 @@ const
 var
   I: Integer;
 begin
+  Result := '';
   for I := 1 to Length(Str) do
     if not CharInSet(Str[I], SAFE_CHARS) then
       Result := Result + '%'+ IntToHex(Ord(Str[I]),2)

--- a/tests/BuildQueryParametersTests.pas
+++ b/tests/BuildQueryParametersTests.pas
@@ -21,12 +21,30 @@ type
   published
     procedure GetQueryParams_WithHTMLBody_EncodedParamsReturned;
     procedure GetQueryParams_WithTextBody_EncodedParamsReturned;
+    procedure GetQueryParams_MutipleRecipients_RecipientsAdded;
   end;
 
 implementation
 
 uses
   AmazonEmailService;
+
+procedure TBuildQueryParametersTests.GetQueryParams_MutipleRecipients_RecipientsAdded;
+const
+  ExpectedRecipients = '&Destination.ToAddresses.member.1=emailFrom%40mail.com' +
+                    '&Destination.ToAddresses.member.2=emailFrom2%40mail.com';
+var
+  EncodedParams: TStringStream;
+begin
+  FRecipients.Add('emailFrom2@mail.com');
+
+  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, 'email@email.com', '', '');
+  try
+    Assert.Contains(EncodedParams.DataString, ExpectedRecipients);
+  finally
+    EncodedParams.Free;
+  end;
+end;
 
 procedure TBuildQueryParametersTests.GetQueryParams_WithHTMLBody_EncodedParamsReturned;
 const


### PR DESCRIPTION
The method was not marked static and the Result was not begin reset, so if called multiple times it would add the strings messing the result.
