### PR TITLE
Do no re-raise the exception when it is an HTTP exception.

### DIFF
--- a/AmazonEmailService.pas
+++ b/AmazonEmailService.pas
@@ -83,15 +83,9 @@ begin
       PopulateResponseInfo(Response, Peer);
     except
       on E: EIPHTTPProtocolExceptionPeer do
-      begin
-        PopulateResponseInfo(Response, E);
+        PopulateResponseInfo(Response, E)
+      else
         raise;
-      end;
-      on E: Exception do
-      begin
-        PopulateResponseInfo(Response, Peer);
-        raise;
-      end;
     end;
   finally
     if Assigned(Peer) then


### PR DESCRIPTION
When there was a bad request or other http exceptions it wasn't returning the correct error message as you would have to read the response in the except block, which isn't very intuitive.
