### PR TITLE
Add FromName parameter and fix encoding of Source to support special chars

### DIFF
--- a/AmazonEmailService.pas
+++ b/AmazonEmailService.pas
@@ -20,17 +20,17 @@ type
     procedure IssueRequest(const QueryParameters: TStringStream; out Response: TCloudResponseInfo);
     procedure PopulateResponseInfo(const ResponseInfo: TCloudResponseInfo; const Peer: IIPHTTP); overload;
     procedure PopulateResponseInfo(const ResponseInfo: TCloudResponseInfo; const E: EIPHTTPProtocolExceptionPeer); overload;
-    function BuildQueryParameters(const Recipients, ReplyTo: TArray<string>; const From, Subject, MessageBody: string):
-        TStringStream;
+    function BuildQueryParameters(const Recipients, ReplyTo: TArray<string>; const FromName, FromAddress, Subject,
+        MessageBody: string): TStringStream;
     procedure PrepareRequest(const Peer: IIPHTTP);
   public
     constructor Create(const Region, AWSAccessKey, AWSSecretKey: string); overload;
     constructor Create; overload;
 
-    function SendMail(const Recipients, ReplyTo: TArray<string>; const FromAddress, Subject, MessageBody: string; out
-        Response: TCloudResponseInfo; const EmailBody: TEmailBody): Boolean; overload;
-    function SendMail(const Recipients, ReplyTo: TArray<string>; const FromAddress, Subject, MessageBody: string; const
-        EmailBody: TEmailBody): Boolean; overload;
+    function SendMail(const Recipients, ReplyTo: TArray<string>; const FromName, FromAddress, Subject, MessageBody: string;
+        out Response: TCloudResponseInfo; const EmailBody: TEmailBody): Boolean; overload;
+    function SendMail(const Recipients, ReplyTo: TArray<string>; const FromName, FromAddress, Subject, MessageBody: string;
+        const EmailBody: TEmailBody): Boolean; overload;
     property EmailBody: TEmailBody read FEmailBody write FEmailBody;
   end;
 
@@ -134,33 +134,33 @@ begin
   end;
 end;
 
-function TAmazonEmailService.SendMail(const Recipients, ReplyTo: TArray<string>; const FromAddress, Subject,
+function TAmazonEmailService.SendMail(const Recipients, ReplyTo: TArray<string>; const FromName, FromAddress, Subject,
     MessageBody: string; const EmailBody: TEmailBody): Boolean;
 var
   Response: TCloudResponseInfo;
 begin
   try
-    Result := SendMail(Recipients, ReplyTo, FromAddress, Subject, MessageBody, Response, EmailBody);
+    Result := SendMail(Recipients, ReplyTo, FromName, FromAddress, Subject, MessageBody, Response, EmailBody);
   finally
     if Assigned(Response) then
       Response.Free;
   end;
 end;
 
-function TAmazonEmailService.BuildQueryParameters(const Recipients, ReplyTo: TArray<string>; const From, Subject,
-    MessageBody: string): TStringStream;
+function TAmazonEmailService.BuildQueryParameters(const Recipients, ReplyTo: TArray<string>; const FromName,
+    FromAddress, Subject, MessageBody: string): TStringStream;
 var
   BuildQueryParameters: TBuildQueryParameters;
 begin
   BuildQueryParameters := TBuildQueryParameters.Create(FEmailBody);
   try
-    Result := BuildQueryParameters.GetQueryParams(Recipients, ReplyTo, From, Subject, MessageBody);
+    Result := BuildQueryParameters.GetQueryParams(Recipients, ReplyTo, FromName, FromAddress, Subject, MessageBody);
   finally
     BuildQueryParameters.Free;
   end;
 end;
 
-function TAmazonEmailService.SendMail(const Recipients, ReplyTo: TArray<string>; const FromAddress, Subject,
+function TAmazonEmailService.SendMail(const Recipients, ReplyTo: TArray<string>; const FromName, FromAddress, Subject,
     MessageBody: string; out Response: TCloudResponseInfo; const EmailBody: TEmailBody): Boolean;
 var
   QueryParameters: TStringStream;
@@ -171,7 +171,7 @@ begin
   try
     Response := TCloudResponseInfo.Create;
 
-    QueryParameters := BuildQueryParameters(Recipients, ReplyTo, FromAddress, Subject, MessageBody);
+    QueryParameters := BuildQueryParameters(Recipients, ReplyTo, FromName, FromAddress, Subject, MessageBody);
     try
       IssueRequest(QueryParameters, Response);
       Result := (Response <> nil) and (Response.StatusCode = 200);

--- a/README.md
+++ b/README.md
@@ -6,34 +6,30 @@ Amazon Simple Email Service ([AWS SES](http://aws.amazon.com/ses)) library for D
 
 If you call the `TAmazonEmailService.Create` constructor without arguments the library will look for the following environment variables: `AWS_REGION`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. 
 
-```pascal
+```Delphi
 var
   AmazonEmailService: TAmazonEmailService;
-  Recipients: TStrings;
-  FromAddress, Subject, MessageBody: string;
+  Recipients: TArray<string>;
+  FromName, FromAddress, Subject, MessageBody: string;
 begin
-  Recipients := TStringList.Create;
-  try
-    Recipients.Add('email@mail.com');
-    FromAddress := 'email@mail.com';
-    Subject := 'This is the subject line with HTML.';
-    MessageBody := 'Hello. I hope you are having a good day.';
+  Recipients := TArray<string>.Create('email@example.com', 'email2@example.com');
+  FromName := 'John Doe'
+  FromAddress := 'email@mail.com';
+  Subject := 'This is the subject line with HTML.';
+  MessageBody := 'Hello. I hope you are having a good day.';
 
-    AmazonEmailService := TAmazonEmailService.Create;
-    try
-      AmazonEmailService.SendMail(Recipients, FromAddress, Subject, MessageBody);
-    finally
-      AmazonEmailService.Free;
-    end;
+  AmazonEmailService := TAmazonEmailService.Create;
+  try
+    AmazonEmailService.SendMail(Recipients, FromName, FromAddress, Subject, MessageBody);
   finally
-    Recipients.Free;
+    AmazonEmailService.Free;
   end;
 end;
 ```
 
 You may also pass parameters to the constructor method:
 
-```pascal
+```Delphi
   // ...
   AmazonEmailService := TAmazonEmailService.Create(AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY);
   // ...
@@ -54,7 +50,7 @@ By default, the email will have HTML-enabled. To use text-based email will need 
 
 It's also possible to get the response information, setting as a parameter to the SendMail method a variable of type TCloudResponseInfo.
 
-```pascal
+```Delphi
 var
   ResponseInfo: TCloudResponseInfo;
 begin
@@ -65,7 +61,7 @@ begin
 
 For example, if the email was sent successfully will be returned:
 
-```pascal
+```Delphi
 Response.StatusCode = 200
 Response.StatusMessage = 'HTTP/1.1 200 OK'
 ```

--- a/tests/BuildQueryParametersTests.pas
+++ b/tests/BuildQueryParametersTests.pas
@@ -25,6 +25,7 @@ type
     procedure GetQueryParams_WithTextBody_EncodedParamsReturned;
     procedure GetQueryParams_MutipleRecipients_RecipientsAdded;
     procedure GetQueryParams_WithReplyToAddresses_AddressesAdded;
+    procedure GetQueryParams_FromNameSpecified_FromNameEncoded;
   end;
 
 implementation
@@ -47,9 +48,23 @@ var
 begin
   AddRecipient('emailFrom2@mail.com');
 
-  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, 'email@email.com', '', '');
+  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, '', 'email@email.com', '', '');
   try
     Assert.Contains(EncodedParams.DataString, ExpectedRecipients);
+  finally
+    EncodedParams.Free;
+  end;
+end;
+
+procedure TBuildQueryParametersTests.GetQueryParams_FromNameSpecified_FromNameEncoded;
+const
+  ExpectedSource = '&Source=%3D%3Futf-8%3FB%3FW0FDTUVdIEpvaG4gRG9l%3F%3D%20%3Cemail%40email.com%3E';
+var
+  EncodedParams: TStringStream;
+begin
+  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, '[ACME] John Doe', 'email@email.com', '', '');
+  try
+    Assert.Contains(EncodedParams.DataString, ExpectedSource);
   finally
     EncodedParams.Free;
   end;
@@ -58,7 +73,7 @@ end;
 procedure TBuildQueryParametersTests.GetQueryParams_WithHTMLBody_EncodedParamsReturned;
 const
   EXPECTED_RETURN = 'Action=SendEmail' +
-                    '&Source=email%40mail.com' +
+                    '&Source=%3D%3Futf-8%3FB%3F%3F%3D%20%3Cemail%40mail.com%3E' +
                     '&Destination.ToAddresses.member.1=emailFrom%40mail.com' +
                     '&Message.Subject.Charset=UTF-8' +
                     '&Message.Subject.Data=This%20is%20the%20subject%20line%20with%20HTML.' +
@@ -88,7 +103,7 @@ begin
     '</body>' +
     '</html>';
 
-  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, FromAddress, Subject, MessageBody);
+  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, '', FromAddress, Subject, MessageBody);
   try
     Assert.AreEqual(EXPECTED_RETURN, EncodedParams.DataString);
   finally
@@ -106,7 +121,7 @@ var
 begin
   ReplyTo := TArray<string>.Create('emailtoreply1@mail.com', 'emailtoreply2@mail.com');
 
-  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, ReplyTo, 'email@email.com', '', '');
+  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, ReplyTo, '', 'email@email.com', '', '');
   try
     Assert.Contains(EncodedParams.DataString, ExpectedRecipients);
   finally
@@ -117,7 +132,7 @@ end;
 procedure TBuildQueryParametersTests.GetQueryParams_WithTextBody_EncodedParamsReturned;
 const
   EXPECTED_RETURN = 'Action=SendEmail' +
-                    '&Source=email%40mail.com' +
+                    '&Source=%3D%3Futf-8%3FB%3F%3F%3D%20%3Cemail%40mail.com%3E' +
                     '&Destination.ToAddresses.member.1=emailFrom%40mail.com' +
                     '&Message.Subject.Charset=UTF-8' +
                     '&Message.Subject.Data=This%20is%20the%20subject%20line.' +
@@ -132,7 +147,7 @@ begin
   MessageBody := 'Hello. I hope you are having a good day.';
 
   FBuildQueryParameters.EmailBody := eText;
-  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, FromAddress, Subject, MessageBody);
+  EncodedParams := FBuildQueryParameters.GetQueryParams(FRecipients, '', FromAddress, Subject, MessageBody);
   try
     Assert.AreEqual(EXPECTED_RETURN, EncodedParams.DataString);
   finally


### PR DESCRIPTION
Special chars like [] were being removed as the Source name and address was not being encoded properly. Now it specify the utf-8 encoding and encodes the source name using base64 ("B" encoding).

Base64 was used to avoid implementing the "Q" encoding as defined in [RFC-2047](http://tools.ietf.org/html/rfc2047).
